### PR TITLE
更新 README & 添加配置属性： sanRequirePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,47 @@
 # fis3-parser-san-component
-===================================
 
-用法参考[fis3-parser-vue-component](https://github.com/ccqgithub/fis3-parser-vue-component)
+
+## 安装
+
+```
+npm install fis3-parser-san-component --save-dev
+```
+
+## 基础配置
+
+```javascript
+fis.match('src/**.san', {
+    isMod: true,
+    rExt: 'js',
+    useSameNameRequire: true,
+    parser: fis.plugin('san-component', {
+
+        // 插件内部会自动注入对 san 的 require 的代码， 默认是 'san'
+        // 对于不使用 npm 来管理依赖的 app，可能有必要手动配置路径
+        sanRequirePath: 'san',
+
+        // css scoped
+        cssScopedIdPrefix: 'scp-', // hash前缀
+        cssScopedHashLength: 8 // hash 长度
+    })
+});
+```
+
+## 异构语言支持
+
+- script： ES6、ts、coffee ...
+- template: jade ...
+- style: less, sass ...
+
+在对应的标签 `template`,`script`,`style` 上添加 `lang` 属性， 然后在 `fis-conf.js` 里配置：
+
+```javascript
+// 以 less 为例
+fis.match('src/**.vue:less', {
+    rExt: 'css',
+    parser: fis.plugin('less'),
+    postprocessor: fis.plugin('autoprefixer')
+})
+```
+
+其他用法参考[fis3-parser-vue-component](https://github.com/ccqgithub/fis3-parser-vue-component)

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var rewriteStyle = require('./lib/style-rewriter');
 
 module.exports = function (content, file, conf) {
     var configs = Object.assign({
+        sanRequirePath: 'san',
         cssScopedIdPrefix: 'scp-',
         cssScopedHashLength: 8
     }, conf || {});
@@ -26,7 +27,7 @@ module.exports = function (content, file, conf) {
 
 
     var output = 'var __san_script__, __san_template__\n' +
-        'var san = require("san")\n';
+        'var san = require("' + configs.sanRequirePath + '")\n';
     // script
     if (result.script && result.script.length != 0) {
         output += fis.compile.partial(result.script[0].content, file, {


### PR DESCRIPTION
- 更新 README

- 添加配置属性： sanRequirePath

    插件内部会自动注入对 san 的 require 的代码， 默认是 'san'
对于不使用 npm 来管理依赖的 app，可能有必要手动配置路径